### PR TITLE
Update for mongo changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ module.exports = function(cursor, limit, each, callback) {
           nextObject();
         });
       }
-      return cursor.nextObject(function(err, doc) {
+      return cursor.next(function(err, doc) {
         fn(err, doc);
         nextObjectActive = false;
         nextObject();

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ module.exports = function(cursor, limit, each, callback) {
           nextObject();
         });
       }
-      return cursor.next(function(err, doc) {
+      return cursor[cursor.nextObject ? 'nextObject' : 'next'](function(err, doc) {
         fn(err, doc);
         nextObjectActive = false;
         nextObject();


### PR DESCRIPTION
`nextObject` has become `next` in recent versions